### PR TITLE
Added EOF at the end of stdin to match the behavior we *say* we have

### DIFF
--- a/core/src/main/scala/fs2/io/ssh/Process.scala
+++ b/core/src/main/scala/fs2/io/ssh/Process.scala
@@ -92,7 +92,10 @@ final class Process[F[_]: Concurrent: ContextShift] private[ssh] (
         fromFuture(F.delay(ioos.writePacket(buffer)))
       }
 
-      written.takeWhile(_ == true).void
+      written.takeWhile(_ == true)
+        .void
+        .onComplete(
+          Stream.eval_(fromFuture(F.delay(ioos.close(false)))))
     }
   }
 }


### PR DESCRIPTION
Ensures that we send EOF at the end of the standard input stream. This makes it so we can't reuse `stdin`, but on the plus side, brings things in line with what the TODO comment *claimed* we did!