### PR TITLE
Add closeImmediately param to Client.exec

### DIFF
--- a/core/src/main/scala/fs2/io/ssh/Client.scala
+++ b/core/src/main/scala/fs2/io/ssh/Client.scala
@@ -29,7 +29,7 @@ import org.apache.sshd.common.SshException
 import org.apache.sshd.common.config.keys.FilePasswordProvider
 import org.apache.sshd.common.keyprovider.FileKeyPairProvider
 
-import scala.{Array, Int, None, Product, Serializable, Some}
+import scala.{Array, Boolean, Int, None, Product, Serializable, Some}
 import scala.util.{Left, Right}
 
 import java.lang.{String, SuppressWarnings}
@@ -50,7 +50,8 @@ final class Client[F[_]: Concurrent: ContextShift] private (client: SshClient) {
       cc: ConnectionConfig,
       command: String,
       blocker: Blocker,
-      chunkSize: Int = 4096)(
+      chunkSize: Int = 4096,
+      closeImmediately: Boolean = false)(
       implicit FR: FunctorRaise[F, Error])
       : Resource[F, Process[F]] = {
 
@@ -64,7 +65,7 @@ final class Client[F[_]: Concurrent: ContextShift] private (client: SshClient) {
           opened <- fromFuture(F.delay(channel.open()))
           // TODO handle failure opening
         } yield channel)(
-        channel => fromFuture(F.delay(channel.close(false))).void)
+        channel => fromFuture(F.delay(channel.close(closeImmediately))).void)
     } yield new Process[F](channel, chunkSize)
   }
 


### PR DESCRIPTION
For using long running commands (say 'tail -f'), it is necessary to finish stdout stream whenever some expected results come and bind Process Resource usage to IO producing stream results. That way, resource is closed  even though command is still running.
The problem lies in ```channel.close(false)``` which is run as part of closing the resource and takes 1 minute to complete (because command is still running and mina ssh client is just waiting for default 1min timeout). It should be possible to close channel immediately for such use case.
Since there is no way to cancel command, this seems to be the only option. And it works :)