### PR TITLE
Bump apache sshd version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ val CatsEffectVersion = "3.4.11"
 val CatsMtlVersion = "1.3.0"
 val Fs2Version = "3.6.1"
 val NettyVersion = "4.1.100.Final"
-val SshdVersion = "2.10.0"
+val SshdVersion = "2.12.1"
 
 // Include to also publish a project's tests
 lazy val publishTestsSettings = Seq(


### PR DESCRIPTION
This version addresses a [CVE](https://nvd.nist.gov/vuln/detail/CVE-2023-48795), which we previously ignored because there was no fix yet, but now this can be fixed.